### PR TITLE
Remove experimental smartmatch operators

### DIFF
--- a/lib/Ruby/VersionManager.pm
+++ b/lib/Ruby/VersionManager.pm
@@ -94,7 +94,6 @@ sub _check_installed {
 }
 
 sub updatedb {
-    no if $] >= 5.018, warnings => "experimental::smartmatch";
     my ($self) = @_;
 
     my @versions = qw( 1.8 1.9 2.0 2.1 );
@@ -199,7 +198,6 @@ sub gem {
 }
 
 sub switch_gemset {
-    no if $] >= 5.018, warnings => "experimental::smartmatch";
     my ( $self, $gemset ) = @_;
 
     if ( $ENV{RUBY_VERSION} && $gemset ) {
@@ -222,7 +220,6 @@ sub switch_gemset {
 }
 
 sub gemsets {
-    no if $] >= 5.018, warnings => "experimental::smartmatch";
     my $self = shift;
 
     my @gemsets = ();
@@ -330,7 +327,6 @@ sub _guess_version {
 }
 
 sub install {
-    no if $] >= 5.018, warnings => "experimental::smartmatch";
     my ($self) = @_;
 
     $self->ruby_version( $self->_guess_version );

--- a/lib/Ruby/VersionManager.pm
+++ b/lib/Ruby/VersionManager.pm
@@ -112,7 +112,7 @@ sub updatedb {
 
         if ( $res->is_success ) {
             $rubies->{$version} = [];
-            for ( grep { $_ ~~ /ruby.*\.tar\.bz2/ } split '\n', $res->content ) {
+            for ( grep { /ruby.*\.tar\.bz2/ } split '\n', $res->content ) {
                 my $at = $self->archive_type;
                 ( my $ruby = $_ ) =~ s/(.*)$at/$1/;
                 push @{ $rubies->{$version} }, ( split ' ', $ruby )[-1];
@@ -210,7 +210,7 @@ sub switch_gemset {
 
         my $installed = $self->installed_rubies->{$major_version};
 
-        if ( $self->ruby_version ~~ @$installed ) {
+        if ( grep { /$self->ruby_version/ } @$installed ) {
             $self->gemset($gemset);
             $self->_setup_environment;
 
@@ -235,7 +235,7 @@ sub gemsets {
 
         my $installed = $self->installed_rubies->{$major_version};
 
-        if ( $self->ruby_version ~~ @$installed ) {
+        if ( grep { /$self->ruby_version/ } @$installed ) {
             my $dir = File::Spec->catdir( $self->rootdir, 'gemsets', $self->major_version, $self->ruby_version );
             opendir my $dh, $dir || die "Could not open $dir.";
 
@@ -339,7 +339,7 @@ sub install {
 
     my $ruby      = $self->ruby_version;
     my $installed = 0;
-    $installed = 1 if join ' ', @{ $self->installed_rubies->{$major_version} } ~~ /$ruby/;
+    $installed = 1 if join ' ', grep { /$ruby/ } @{ $self->installed_rubies->{$major_version} };
 
     if ( not $installed ) {
         $self->_fetch_ruby;


### PR DESCRIPTION
Smartmatch operator is considered experimental in >=perl-5.18. This patch replaces them with casual `grep`s and cleans up `warnings` pragma overrides.