### PR TITLE
Add exec command to set up PATHs on demand

### DIFF
--- a/lib/Ruby/VersionManager.pm
+++ b/lib/Ruby/VersionManager.pm
@@ -95,6 +95,34 @@ sub _check_installed {
 
 }
 
+sub exec_with_path {
+    my ( $self, $action, @args ) = @_;
+
+    open my $fh, (join '/', cwd(), '.ruby-version');
+    my $ruby_version = <$fh>;
+    close $fh;
+
+    $self->ruby_version($ruby_version);
+    ( my $major_version = $self->ruby_version ) =~ s/(\d\.\d).*/$1/;
+    $self->major_version($major_version);
+
+    $ENV{PATH} = $self->_clean_path;
+
+    $ENV{RUBY_VERSION} = $self->ruby_version;
+    $ENV{GEM_PATH} = File::Spec->catdir( abs_path( $self->rootdir ), 'gemsets', $self->major_version, $self->ruby_version, $self->gemset );
+    $ENV{GEM_HOME} = File::Spec->catdir( abs_path( $self->rootdir ), 'gemsets', $self->major_version, $self->ruby_version, $self->gemset );
+    $ENV{MY_RUBY_HOME} = File::Spec->catdir( abs_path( $self->rootdir ), 'rubies', $self->major_version, $self->ruby_version );
+    $ENV{PATH} = File::Spec->catdir( abs_path( $self->rootdir ), 'rubies', $self->major_version, $self->ruby_version, 'bin' )
+      . ':'
+      . File::Spec->catdir( abs_path( $self->rootdir ), 'gemsets', $self->major_version, $self->ruby_version, $self->gemset, 'bin' )
+      . ':'
+      . $ENV{PATH};
+
+    system($action, @args);
+
+    return 1;
+}
+
 sub updatedb {
     my ($self) = @_;
 

--- a/script/rvm.pl
+++ b/script/rvm.pl
@@ -42,6 +42,9 @@ my $dispatch_table = {
         $rvm->ruby_version($ruby_version);
         $rvm->install;
     },
+    exec => sub {
+        $rvm->exec_with_path(@options);
+    },
     uninstall => sub {
         my $ruby_version = shift @options;
         die "no version defined" unless $ruby_version;


### PR DESCRIPTION
Basically same as `rbenv exec` - set all the paths so in scripts we can use `rvm.pl exec bundle exec rake` and it'll pick up the right ruby/bundler/etc. Also works only if there is `.ruby-version` file in the current directory.